### PR TITLE
小尾巴自定义正则过滤

### DIFF
--- a/app/src/main/java/nil/nadph/qnotified/config/ConfigItems.java
+++ b/app/src/main/java/nil/nadph/qnotified/config/ConfigItems.java
@@ -43,6 +43,8 @@ public class ConfigItems {
     public static final String qn_chat_tail_troops = "qn_chat_tail_troops";
     public static final String qn_chat_tail_friends = "qn_chat_tail_friends";
     public static final String qn_chat_tail_global = "qn_chat_tail_global";
+    public static final String qn_chat_tail_regex = "qn_chat_tail_regex";
+    public static final String qn_chat_tail_regex_text = "qn_chat_tail_regex_text";
     public static final String qn_script_global = "qn_script_global";
     public static final String qn_script_count = "qn_script_count";
     public static final String qn_script_code = "qn_script_code_";


### PR DESCRIPTION
容许用户通过自定义正则表达式的方式来判断是否对当前消息添加小尾巴
PS.仅当正则表达式通过时不会携带小尾巴（防止用户写错表达式导致小尾巴功能不生效）